### PR TITLE
[Pull Request] Script refinement to allow unit tests to run  and bugs fix

### DIFF
--- a/GetCurrentTemperature.bats
+++ b/GetCurrentTemperature.bats
@@ -1,0 +1,210 @@
+setup()
+{
+   load './test/setup'
+   _common_setup
+}
+
+teardown()
+{
+   _common_teardown
+}
+
+beforeEach()
+{
+   _common_beforeEach
+}
+
+#   if [ -f "/tmp/myAirContants.txt" ]; then rm "/tmp/myAirConstants.txt";fi
+
+@test "AdvAir ( ezone inline ) Test PassOn5 Get CurrentTemperature" {
+   # We symbolically link the directory of the test we want to use.
+   ln -s ./testData/dataPassOn5 ./data
+   beforeEach
+   if [ -f "/tmp/myAirContants.txt_TEST" ]; then rm "/tmp/myAirConstants.txt_TEST";fi
+   # Bats "run" gobbles up all the stdout. Remove for debugging
+   run ./compare/ezone.txt Get Blah CurrentTemperature TEST_ON
+   assert_equal "$status" 0
+   assert_equal "${lines[0]}" "Try 0"
+   assert_equal "${lines[1]}" "Try 1"
+   assert_equal "${lines[2]}" "Try 2"
+   assert_equal "${lines[3]}" "Try 3"
+   assert_equal "${lines[4]}" "Try 4"
+   assert_equal "${lines[5]}" "25.4"
+   e_status=$status
+   e_lines=("${lines[@]}")
+   run ./compare/AdvAir.sh Get Blah CurrentTemperature TEST_ON 192.168.0.173 z01
+   assert_equal "$status" "$e_status"
+   assert_equal "${lines[0]}" "Using IP: 192.168.0.173"
+   assert_equal "${lines[1]}" "${e_lines[0]}"
+   assert_equal "${lines[2]}" "${e_lines[1]}"
+   assert_equal "${lines[3]}" "${e_lines[2]}"
+   assert_equal "${lines[4]}" "${e_lines[3]}"
+   assert_equal "${lines[5]}" "${e_lines[4]}"
+   assert_equal "${lines[6]}" "${e_lines[5]}"
+}
+
+@test "AdvAir ( ezone inline ) Test PassOn1 Get CurrentTemperature" {
+   ln -s ./testData/dataPassOn1 ./data
+   beforeEach
+   run ./compare/ezone.txt Get Blah CurrentTemperature TEST_ON
+   assert_equal "$status" 0
+   assert_equal "${lines[0]}" "Try 0"
+   e_status=$status
+   e_lines=("${lines[@]}")
+   run ./compare/AdvAir.sh Get Blah CurrentTemperature TEST_ON 192.168.0.173 z01
+   assert_equal "$status" "$e_status"
+   assert_equal "${lines[0]}" "Using IP: 192.168.0.173"
+   assert_equal "${lines[1]}" "${e_lines[0]}"
+}
+
+@test "AdvAir ( ezone inline ) Test PassOn3 Get CurrentTemperature" {
+   ln -s ./testData/dataPassOn3 ./data
+   beforeEach
+   run ./compare/ezone.txt Get Blah CurrentTemperature TEST_ON
+   assert_equal "$status" 0
+   assert_equal "${lines[0]}" "Try 0"
+   assert_equal "${lines[1]}" "Try 1"
+   assert_equal "${lines[2]}" "Try 2"
+   e_status=$status
+   e_lines=("${lines[@]}")
+   run ./compare/AdvAir.sh Get Blah CurrentTemperature TEST_ON 192.168.0.173 z01
+   assert_equal "$status" "$e_status"
+   assert_equal "${lines[0]}" "Using IP: 192.168.0.173"
+   assert_equal "${lines[1]}" "${e_lines[0]}"
+   assert_equal "${lines[2]}" "${e_lines[1]}"
+   assert_equal "${lines[3]}" "${e_lines[2]}"
+}
+
+@test "AdvAir ( ezone inline ) Test FailOn5 Get CurrentTemperature" {
+   ln -s ./testData/dataFailOn5 ./data
+   beforeEach
+   run ./compare/ezone.txt Get Blah CurrentTemperature TEST_ON
+   assert_equal "$status" 1
+   assert_equal "${lines[0]}" "Try 0"
+   assert_equal "${lines[1]}" "Try 1"
+   assert_equal "${lines[2]}" "Try 2"
+   assert_equal "${lines[3]}" "Try 3"
+   assert_equal "${lines[4]}" "Try 4"
+   e_status=$status
+   e_lines=("${lines[@]}")
+   run ./compare/AdvAir.sh Get Blah CurrentTemperature TEST_ON 192.168.0.173 z01
+   assert_equal "$status" "$e_status"
+   assert_equal "${lines[0]}" "Using IP: 192.168.0.173"
+   assert_equal "${lines[1]}" "${e_lines[0]}"
+   assert_equal "${lines[2]}" "${e_lines[1]}"
+   assert_equal "${lines[3]}" "${e_lines[2]}"
+   assert_equal "${lines[4]}" "${e_lines[3]}"
+   assert_equal "${lines[5]}" "${e_lines[4]}"
+}
+
+
+@test "AdvAir ( zones inline ) Test PassOn1 Get CurrentTemperature z01" {
+   ln -s ./testData/dataPassOn1 ./data
+   beforeEach
+   run ./compare/zones.txt Get Blah CurrentTemperature z01 TEST_ON
+   assert_equal "$status" 0
+   assert_equal "${lines[0]}" "Try 0"
+   e_status=$status
+   e_lines=("${lines[@]}")
+   run ./compare/AdvAir.sh Get Blah CurrentTemperature TEST_ON 192.168.0.173 z01
+   assert_equal "$status" "$e_status"
+   assert_equal "${lines[0]}" "Using IP: 192.168.0.173"
+   assert_equal "${lines[1]}" "${e_lines[0]}"
+}
+
+@test "AdvAir ( zones inline ) Test PassOn3 Get CurrentTemperature z01" {
+   ln -s ./testData/dataPassOn3 ./data
+   beforeEach
+   run ./compare/zones.txt Get Blah CurrentTemperature z01 TEST_ON
+   assert_equal "$status" 0
+   assert_equal "${lines[0]}" "Try 0"
+   assert_equal "${lines[1]}" "Try 1"
+   assert_equal "${lines[2]}" "Try 2"
+   e_status=$status
+   e_lines=("${lines[@]}")
+   run ./compare/AdvAir.sh Get Blah CurrentTemperature TEST_ON 192.168.0.173 z01
+   assert_equal "$status" "$e_status"
+   assert_equal "${lines[0]}" "Using IP: 192.168.0.173"
+   assert_equal "${lines[1]}" "${e_lines[0]}"
+   assert_equal "${lines[2]}" "${e_lines[1]}"
+   assert_equal "${lines[3]}" "${e_lines[2]}"
+}
+
+@test "AdvAir ( zones inline ) Test PassOn5 Get CurrentTemperature z01" {
+   ln -s ./testData/dataPassOn5 ./data
+   beforeEach
+   run ./compare/zones.txt Get Blah CurrentTemperature z01 TEST_ON
+   assert_equal "$status" 0
+   assert_equal "${lines[0]}" "Try 0"
+   assert_equal "${lines[1]}" "Try 1"
+   assert_equal "${lines[2]}" "Try 2"
+   assert_equal "${lines[3]}" "Try 3"
+   assert_equal "${lines[4]}" "Try 4"
+   assert_equal "${lines[5]}" "25.4"
+   e_status=$status
+   e_lines=("${lines[@]}")
+   run ./compare/AdvAir.sh Get Blah CurrentTemperature TEST_ON 192.168.0.173 z01
+   assert_equal "$status" "$e_status"
+   assert_equal "${lines[0]}" "Using IP: 192.168.0.173"
+   assert_equal "${lines[1]}" "${e_lines[0]}"
+   assert_equal "${lines[2]}" "${e_lines[1]}"
+   assert_equal "${lines[3]}" "${e_lines[2]}"
+   assert_equal "${lines[4]}" "${e_lines[3]}"
+   assert_equal "${lines[5]}" "${e_lines[4]}"
+   assert_equal "${lines[6]}" "${e_lines[5]}"
+}
+
+@test "AdvAir ( zones inline ) Test FailOn5 Get CurrentTemperature z01" {
+   ln -s ./testData/dataFailOn5 ./data
+   beforeEach
+   run ./compare/zones.txt Get Blah CurrentTemperature z01 TEST_ON
+   assert_equal "$status" 1
+   assert_equal "${lines[0]}" "Try 0"
+   assert_equal "${lines[1]}" "Try 1"
+   assert_equal "${lines[2]}" "Try 2"
+   assert_equal "${lines[3]}" "Try 3"
+   assert_equal "${lines[4]}" "Try 4"
+   e_status=$status
+   e_lines=("${lines[@]}")
+   run ./compare/AdvAir.sh Get Blah CurrentTemperature TEST_ON 192.168.0.173 z01
+   assert_equal "$status" "$e_status"
+   assert_equal "${lines[0]}" "Using IP: 192.168.0.173"
+   assert_equal "${lines[1]}" "${e_lines[0]}"
+   assert_equal "${lines[2]}" "${e_lines[1]}"
+   assert_equal "${lines[3]}" "${e_lines[2]}"
+   assert_equal "${lines[4]}" "${e_lines[3]}"
+   assert_equal "${lines[5]}" "${e_lines[4]}"
+}
+
+@test "AdvAir ( zones inline ) Test PassOn1 Get CurrentTemperature z03" {
+   ln -s ./testData/dataPassOn1 ./data
+   beforeEach
+   run ./compare/zones.txt Get Blah CurrentTemperature z03 TEST_ON
+   assert_equal "$status" 0
+   assert_equal "${lines[0]}" "Try 0"
+   e_status=$status
+   e_lines=("${lines[@]}")
+   run ./compare/AdvAir.sh Get Blah CurrentTemperature TEST_ON 192.168.0.173 z03
+   assert_equal "$status" "$e_status"
+   assert_equal "${lines[0]}" "Using IP: 192.168.0.173"
+   assert_equal "${lines[1]}" "${e_lines[0]}"
+}
+
+@test "AdvAir ( ezone inline ) Test PassOn1 Get CurrentTemperature with NoSensor Data" {
+   # We symbolically link the directory of the test we want to use.
+   #ln -s ./testData/dataPassOn1 ./data
+   ln -s ./testData/dataOneZone ./data
+   beforeEach
+   # Bats "run" gobbles up all the stdout. Remove for debugging
+   run ./compare/ezone.txt Get Blah CurrentTemperature TEST_ON
+   assert_equal "$status" 0
+   assert_equal "${lines[0]}" "Try 0"
+   assert_equal "${lines[1]}" "25.4"
+   e_status=$status
+   e_lines=("${lines[@]}")
+   run ./compare/AdvAir.sh Get Blah CurrentTemperature TEST_ON
+   assert_equal "$status" "$e_status"
+   assert_equal "${lines[0]}" "${e_lines[0]}"
+   # The noSensors fixes this
+   assert_equal "${lines[1]}" "23"
+}

--- a/setup
+++ b/setup
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+_common_setup()
+{
+   # This setup script would be called from the git home directory
+   load 'node_modules/bats-support/load.bash'
+   load 'node_modules/bats-assert/load.bash'
+   # get the containing directory of this file
+   # use $BATS_TEST_FILENAME instead of ${BASH_SOURCE[0]} or $0,
+   # as those will point to the bats executable's location or the preprocessed file respectively
+   PROJECT_ROOT="$( cd "$( dirname "$BATS_TEST_FILENAME" )/.." >/dev/null 2>&1 && pwd )"
+   # make executables in src/ visible to PATH
+   PATH="$PROJECT_ROOT/src:$PATH"
+
+   cd "$PROJECT_ROOT/test"
+
+   # Remove previous symbolic link tests.
+   # Note:  This is called even if skip is used.
+   if [ -L "./data" ]; then
+      rm ./data
+   fi
+
+}
+
+_common_teardown()
+{
+   # Remove final symbolic link so its not left around.
+   if [ -L "./data" ]; then
+      rm ./data
+   fi
+}
+
+_common_beforeEach()
+{
+   # Constants can change with different data
+   MY_AIR_CONSTANTS_FILE="/tmp/myAirConstants.txt_TEST"
+   if [ -f "${MY_AIR_CONSTANTS_FILE}" ]; then
+      rm "${MY_AIR_CONSTANTS_FILE}"
+   fi
+}
+
+_common_compareAgainstZones()
+{
+   local io=$1
+   local device=$2
+   local characteristic=$3
+   local zones=$4
+   local testOnOff=$5
+
+   # Bats "run" gobbles up all the stdout. Remove for debugging
+   run ./compare/zones.txt $io $device $characteristic $zones $testOnOff
+   z_status=$status
+   z_lines=("${lines[@]}")
+   run ./compare/AdvAir.sh  $io $device $characteristic $zones $testOnOff
+   assert_equal "$status" "$z_status" ]
+   assert_equal "${lines[0]}" "${z_lines[0]}"
+   assert_equal "${lines[1]}" "${z_lines[1]}"
+   assert_equal "${lines[2]}" "${z_lines[2]}"
+   assert_equal "${lines[3]}" "${z_lines[3]}"
+   assert_equal "${lines[4]}" "${z_lines[4]}"
+   assert_equal "${lines[5]}" "${z_lines[5]}"
+
+}
+
+_common_compareAgainstEzone()
+{
+   local io=$1
+   local device=$2
+   local characteristic=$3
+   local testOnOff=$4
+
+   # Bats "run" gobbles up all the stdout. Remove for debugging
+   run ./compare/ezone.txt $io $device $characteristic $testOnOff
+   e_status=$status
+   e_lines=("${lines[@]}")
+   run ./compare/AdvAir.sh $io $device $characteristic $zones $testOnOff
+   assert_equal "$status" "$e_status" ]
+   assert_equal "${lines[0]}" "${e_lines[0]}"
+   assert_equal "${lines[1]}" "${e_lines[1]}"
+   assert_equal "${lines[2]}" "${e_lines[2]}"
+   assert_equal "${lines[3]}" "${e_lines[3]}"
+   assert_equal "${lines[4]}" "${e_lines[4]}"
+   assert_equal "${lines[5]}" "${e_lines[5]}"
+}


### PR DESCRIPTION
---
name: Script refinement & bugs fix
about: Resolve an issue 
title: "Script refined to allow unit tests to run and bugs fixed"
labels: pull-request
assignees: mitch7391

---

 AdvAir is refined to allow the running of `unit tests` and some bugs discovered are fixed.

**Is your pull request related to a problem or a new feature? Please describe:**
Problems:
- The AdvAir.sh has issues related to the running of the `unit tests` 
- There are a few double calls to queryAirCon that hindered the smooth runnig of `unit tests`
- There are some minor bugs discovered 

**Describe the solution you'd have implemented:**
- [x] Put appropriate `if [ "$selfTest" = "TEST_ON" ]` statements within the script and removed all double calls to queryAirCon function.to facilitate a smooth running of the `unit tests`.
- [x] A suffix `_TEST` is added to all temporary and log files generated from the running of the `unit tests`.
- [x] A few bugs, for example, inappropriate double quotes,  required data not extracted from an array, etc. whatever discovered are fixed.

**Do your changes pass local testing:**
- [x] Yes  on both E-zone system and MyPlace system.  Passed shellcheck and passed `unit tests`.
<!-- If unclear, I can update these afterwards. -->

**Additional context:**
I have included the `_TEST` suffix to the temporary file name `/tmp/myAirConstants.txt` in the `setup` and `GetCurrentTemperature.bats` files of the `unit tests` to become `/tmp/myAirConstants.txt_TEST`.  This is necessary to order to prevent any interference with the smooth running of this version of AdvAir.sh on Homebridge.

<!-- Click the "Preview" tab before you submit to ensure the formatting is correct. -->
