### PR TITLE
[Pull Request] ConfigCreator Bug fix for Mac users

### DIFF
--- a/ConfigCreator.sh
+++ b/ConfigCreator.sh
@@ -573,7 +573,7 @@ function extractNonAAdevices()
    AAline=$(grep -n 'state_cmd' "${cmd4ConfigNonAA}"|grep 'cmd4-advantageair'|cut -d":" -f1|head -n 1)
 
    until [ -z "${AAline}" ]; do
-      grep -n '"type":' "${cmd4ConfigNonAA}"|grep -v '                    "type":'|cut -d":" -f1|tac|while read -r line;
+      grep -n '"type":' "${cmd4ConfigNonAA}"|grep -v '                    "type":'|cut -d":" -f1|sort -nr|while read -r line;
       do
          line1=$((line - 1)) 
          if [ "${line1}" -lt "${AAline}" ]; then
@@ -648,7 +648,7 @@ function extractNonAAqueueTypes()
       accessoriesLine=$(grep -n '"accessories":' "${cmd4ConfigNonAA}"|grep -v '     "accessories":'|cut -d":" -f1)
       grep 'queue' "${cmd4ConfigQueueTypesNonAA}"|grep -v 'queueType'|cut -d":" -f1,2|while read -r queue;
       do
-         queueLine=$(grep -n "${queue}" "${cmd4ConfigNonAA}"|cut -d":" -f1|tac|head -n 1)
+         queueLine=$(grep -n "${queue}" "${cmd4ConfigNonAA}"|cut -d":" -f1|sort -nr|head -n 1)
          if [ "${queueLine}" -lt "${accessoriesLine}" ]; then
             line=$(grep -n "${queue}" "${cmd4ConfigQueueTypesNonAA}"|cut -d":" -f1)
             line1=$((line - 1))


### PR DESCRIPTION
changed the command "tac" to "sort -nr".  Command "tac" is not available on Mac.

---
name: Pull Request
about: Resolve an issue on ConfigCreator for Mac users
title: "Bug fix on ConfigCreator for Mac users"
labels: bug fix
assignees: mitch7391

---

<!-- Provide a general summary in the Title above -->
The command "tac" is to reverse the sorting order of a file but its not available on Mac machines.  As such, the command "sort -nr" is used instead, so that it works for all.
**Is your pull request related to a problem or a new feature? Please describe:**
<!-- A clear and concise description of what the problem is. E.g. "Mitch, there needs to be a button to buy you a coffee!" -->
this pull request is related to a bug for Mac users.
**Describe the solution you'd have implemented:**
<!-- A clear and concise description of what you your pull request is for. Explain the technical solution you have provided and how it addresses the issue. -->
Used the command "sort -nr" instead of "tac".

**Do your changes pass local testing:**
- [x] Yes
<!-- If unclear, I can update these afterwards. -->

**Additional context:**
<!-- Add any other context or screenshots about the pull request here. -->

<!-- Click the "Preview" tab before you submit to ensure the formatting is correct. -->
