### PR TITLE
[Pull Request] Running ConfigCreator from Custom Homebridge Ui

### DIFF
--- a/ConfigCreator.sh
+++ b/ConfigCreator.sh
@@ -754,7 +754,7 @@ for ((n=1; n<=noOfTablets; n++)); do
       queue="AAC"
    fi
 
-   myAirData=$(curl -s -g --max-time 15 --fail --connect-timeout 15 "http://${IPA}:2025/getSystemData")
+   myAirData=$(curl -s -g --max-time 45 --fail --connect-timeout 45 "http://${IPA}:2025/getSystemData")
    #
    if [ -z "$myAirData" ]; then
       echo "ERROR: AdvantageAir system is inaccessible or your IP address ${IPA} is invalid!"

--- a/ConfigCreator.sh
+++ b/ConfigCreator.sh
@@ -5,28 +5,37 @@
 #
 # usage:
 #   This script is called from Homebridge customUi server
-#   The AA systems name(s) and IP address(es) are from cmd4AdvantageAir plugin config via the customUi server
+#   The name(s) and IP address(es) of the AA system(s) are taken from cmd4AdvantageAir plugin config
+#   which can be entered via the `Setting` of the plugin or edit the config directly using JASON Config Editor. 
 #      
-#   If you know what you are doing you can do some edits on this configuration file in the Cmd4 JASON Config Editor,
-#   like changing some names or deleting some accessories you do not need, etc, click SAVE when you are done.
+#   Once the Cmd4 configuration file is generated and if you know what you are doing you can do some edits
+#   on this configuration file in the Cmd4 JASON Config Editor. 
+#   Click SAVE when you are done.
 #
 #   NOTE:  If you need to 'flip' the GarageDoorOpener, you have to add that in yourself.
 # 
 
-if expr "$1" : '[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*$' >/dev/null; then
-   AAIP="$1"
-   AAname="$2"
+AAIP="$1"
+AAname="$2"
+AAIP2="$3"
+AAname2="$4"
+AAIP3="$5"
+AAname3="$6"
+fanSetup="$7"
+ADVAIR_SH_PATH="$8"
+
+if expr "${AAIP}" : '[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*$' >/dev/null; then
+   return
 else
-   echo "ERROR: the specified IP address $1 is in wrong format"
+   echo "ERROR: the specified IP address ${AAIP} is in wrong format"
    exit 1
 fi
 
-if [[ -n "$3" && "$3" != "undefined" ]]; then 
-   if expr "$3" : '[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*$' >/dev/null; then
-      AAIP2="$3"
-      AAname2="$4"
+if [[ -n "${AAIP2}" && "${AAIP2}" != "undefined" ]]; then 
+   if expr "${AAIP2}" : '[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*$' >/dev/null; then
+      return
    else
-      echo "ERROR: the specified IP address $2 is in wrong format"
+      echo "ERROR: the specified IP address ${AAIP2} is in wrong format"
       exit 1
    fi
 else
@@ -34,13 +43,11 @@ else
    AAname2=""
 fi
 
-if [[ -n "$5" && "$5" != "undefined" ]]; then 
+if [[ -n "${AAIP3}" && "${AAIP3}" != "undefined" ]]; then 
    if expr "$5" : '[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*$' >/dev/null; then
-      AAIP3="$5"
-      AAname3="$6"
-      
+     return 
    else
-      echo "ERROR: the specified IP address $3 is in wrong format"
+      echo "ERROR: the specified IP address ${AAIP3} is in wrong format"
       exit 1
    fi
 else
@@ -48,7 +55,6 @@ else
    AAname3=""
 fi
 
-ADVAIR_SH_PATH="$7"
 
 
 # define some other variables
@@ -795,7 +801,12 @@ for ((n=1; n<=noOfTablets; n++)); do
             #name=$(echo "$myAirData" | jq -e ".aircons.${ac}.info.name" | sed 's/ /_/g' | sed 's/\"//g')
             cmd4Thermostat "${cmd4ConfigAccessoriesAA}" "${nameA}"
             cmd4FanLinkTypes "${cmd4ConfigAccessoriesAA}" "${nameA} FanSpeed"
-            cmd4Fan "${cmd4ConfigAccessoriesAA}" "${nameA} Fan"
+            if [ "${fanSetup}" = "fan" ]; then
+               cmd4Fan "${cmd4ConfigAccessoriesAA}" "${nameA} Fan"
+            else
+               cmd4FanSwitch "${cmd4ConfigAccessoriesAA}" "${nameA} Fan"
+               cmd4FanLinkTypes "${cmd4ConfigAccessoriesAA}" "${nameA} FanSpeed"
+            fi
             cmd4TimerLightbulb "${cmd4ConfigAccessoriesAA}" "${nameA} Timer"
             #
             nZones=$(echo "$myAirData" | jq -e ".aircons.${ac}.info.noOfZones")

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,20 +1,58 @@
 {
-   "pluginAlias": "cmd4AdvantageAir",
-   "pluginType": "platform",
-   "headerDisplay": "Advantage Air",
-   "singular": false,
-   "customUi": true,
-   "schema":
-   {
-      "debug":
-      {
-         "title": "debug",
-         "type": "boolean",
-         "description": "Enables additional output in the log.",
-         "required": false,
-         "placeholder": false
-      }
-   }
+    "pluginAlias": "cmd4AdvantageAir",
+    "pluginType": "platform",
+    "singular": true,
+    "customUi": true,
+    "headerDisplay": "Homebridge plugin for AdvantageAir devices",
+    "schema": {
+        "debug": {
+           "title": "debug",
+           "type": "boolean",
+           "description": "Enables additional output in the log.",
+           "required": false,
+           "placeholder": false
+        },
+        "type": "object",
+        "properties": {
+            "name": {
+                "title": "Name",
+                "type": "string",
+                "default": "cmd4AdvantageAir"
+            },
+            "devices": {
+                "type": "array",
+                "items": {
+                    "title": "AdvantageAir device",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "title": "Name",
+                            "description": "The name of the AdvantageAir device.",
+                            "type": "string",
+                            "required": true,
+                            "default": ""
+                        },
+                        "ipAddress": {
+                            "title": "IP Address",
+                            "description": "The device's IP address. It is recommended to set a static IP for this device.",
+                            "type": "string",
+                            "format": "ipv4",
+                            "required": true,
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        }
+    },
+ "layout": [{
+      "key": "devices",
+      "type": "tabarray",
+      "title": "{{ value.name || 'new device' }}",
+      "description": "A maximum of 3 AdvantageAir devices allowed.",
+      "items": [
+        "devices[].name",
+        "devices[].ipAddress"
+      ]
+   }]
 }
-
-

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,58 +1,62 @@
 {
-    "pluginAlias": "cmd4AdvantageAir",
-    "pluginType": "platform",
-    "singular": true,
-    "customUi": true,
-    "headerDisplay": "Homebridge plugin for AdvantageAir devices",
-    "schema": {
-        "debug": {
-           "title": "debug",
-           "type": "boolean",
-           "description": "Enables additional output in the log.",
-           "required": false,
-           "placeholder": false
-        },
-        "type": "object",
-        "properties": {
-            "name": {
-                "title": "Name",
-                "type": "string",
-                "default": "cmd4AdvantageAir"
-            },
-            "devices": {
-                "type": "array",
-                "items": {
-                    "title": "AdvantageAir device",
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "title": "Name",
-                            "description": "The name of the AdvantageAir device.",
-                            "type": "string",
-                            "required": true,
-                            "default": ""
-                        },
-                        "ipAddress": {
-                            "title": "IP Address",
-                            "description": "The device's IP address. It is recommended to set a static IP for this device.",
-                            "type": "string",
-                            "format": "ipv4",
-                            "required": true,
-                            "default": ""
-                        }
-                    }
-                }
+   "pluginAlias": "cmd4AdvantageAir",
+   "pluginType": "platform",
+   "singular": true,
+   "customUi": true,
+   "headerDisplay": "Homebridge plugin for AdvantageAir devices",
+   "schema": {
+      "debug": {
+         "title": "debug",
+         "type": "boolean",
+         "description": "Enables additional output in the log.",
+         "required": false,
+         "placeholder": false
+      },
+      "type": "object",
+      "properties": {
+         "devices": {
+            "type": "array",
+            "items": {
+               "title": "AdvantageAir device",
+               "type": "object",
+               "properties": {
+                  "name": {
+                     "title": "Name",
+                     "description": "The name of the AdvantageAir device.",
+                     "type": "string",
+                     "required": true,
+                     "placeholder": "Aircon"
+                  },
+                  "ipAddress": {
+                     "title": "IP Address",
+                     "description": "The device's IP address. It is recommended to set a static IP for this device.",
+                     "type": "string",
+                     "format": "ipv4",
+                     "required": true,
+                     "placeholder": "192.168.0.1"
+                  }
+               }
             }
-        }
-    },
- "layout": [{
+         }
+      }
+   },
+   "layout": [
+      {
+      "type": "fieldset",
+      "title": "AdvantageAir Device Settings",
+      "description": "Enter below the name and IP address of your AdvantageAir device.",
+      "items": [
+         ]
+      },
+      {
       "key": "devices",
       "type": "tabarray",
       "title": "{{ value.name || 'new device' }}",
-      "description": "A maximum of 3 AdvantageAir devices allowed.",
+      "description": "A maximum of 3 AdvantageAir devices will be processed.",
       "items": [
-        "devices[].name",
-        "devices[].ipAddress"
-      ]
-   }]
+         "devices[].name",
+         "devices[].ipAddress"
+         ]
+      }
+   ]
 }

--- a/config.schema.json
+++ b/config.schema.json
@@ -14,6 +14,12 @@
       },
       "type": "object",
       "properties": {
+         "name": {
+           "title": "Name",
+           "type": "string",
+           "default": "cmd4AdvantageAir",
+           "required": true
+         },
          "devices": {
             "type": "array",
             "items": {
@@ -52,7 +58,7 @@
       "key": "devices",
       "type": "tabarray",
       "title": "{{ value.name || 'new device' }}",
-      "description": "A maximum of 3 AdvantageAir devices will be processed.",
+      "description": "Note: only a maximum of 3 AdvantageAir devices can be processed by Config Creator.",
       "items": [
          "devices[].name",
          "devices[].ipAddress"

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -1,10 +1,13 @@
+<link rel="stylesheet" href="css/style.css">
 <div class="card card-body">
   <img src="images/AdvAir.png" alt="Advantage Air" width="150px" class="center-it cmd4Logo">
   <h5 class="text-center"><b style="font-weight: 600;">Advantage Air Configuration Creator</b></h5>
   <h6 class="text-center">This script will create the AdvantageAir configuration file for Cmd4 Plugin based on the info from your AdvantageAir system! </h6>
-  <br>
   <div class="text-center">
     <button id="ConfigCreatorButton" type="button" class="btn btn-primary">Config Creator</button>
+  </div>
+  <div>
+    <input type="checkbox" id="fanSetup"> "Fan" setup as "FanSwitch"
   </div>
   <div class="form-group">
     <label for="feedbackOutput">Feedback messages from ConfigCreator (read only)</label>
@@ -12,7 +15,6 @@
   </div>
 </div>
 
-<link rel="stylesheet" href="css/style.css">
 <div id="main" class="card card-body pb-5">
 
   <!-- start -->
@@ -74,6 +76,7 @@
     AAIP3 = "";
     AAname3 = "";
     feedback = "";
+    var fanSetup;
 
     // get the intial from the config and add it to the form
     if (pluginConfig.length) {
@@ -94,7 +97,6 @@
     // watch for click events on the ConfigCreatorButton
     document.querySelector('#ConfigCreatorButton').addEventListener('click', async () => {
 
-
       if (pluginConfig[0].devices.length === 0) {
         homebridge.toast.error(`No device defined yet. Please define at least 1 device and SAVE it.`, 'Error');
         return;
@@ -106,6 +108,14 @@
         homebridge.toast.error('An ip address of your AdvantageAir system must be provided.', 'Error');
         return;
       }
+
+      if (document.getElementById("fanSetup").checked == true) {
+         fanSetup = "fanSwitch";
+      } else {
+         fanSetup = "fan";
+      }
+      document.querySelector('#feedbackOutput').value = fanSetup;
+
 
       // starting the request, show the loading spinner
       homebridge.showSpinner();
@@ -132,14 +142,15 @@
           name2: AAname2,
           ip3: AAIP3,
           name3: AAname3,
+          fanSetup: fanSetup,
           feedback: feedback 
         });
 
-        // update the ipform input with the response
+        // update the #feedbackOutput with the response
         document.querySelector('#feedbackOutput').value = response.feedback;
 
         if(response.feedback.includes("ERROR")) {
-           // creat a red toast notification of the error
+           // create a red toast notification of the error
            homebridge.toast.error(`${response.feedback}`, 'Error');
            return;
         } else if(response.feedback.includes("DONE")) {

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -7,7 +7,7 @@
     <button id="ConfigCreatorButton" type="button" class="btn btn-primary">Config Creator</button>
   </div>
   <div>
-    <input type="checkbox" id="fanSetup"> "Fan" setup as "FanSwitch"
+    <input type="checkbox" id="fanSetup" checked> "Fan" setup as "FanSwitch"
   </div>
   <div class="form-group">
     <label for="feedbackOutput">Feedback messages from ConfigCreator (read only)</label>
@@ -122,15 +122,12 @@
 
       // request key paths from the server
       if(pluginConfig[0].devices.length === 1) {
-         // creat a warning toast notification of the error
          homebridge.toast.info(`This process may take up to 1 minute`, 'Info');
       }
       if(pluginConfig[0].devices.length === 2) {
-         // creat a warning toast notification of the error
          homebridge.toast.info(`This process may take up to 2 minutes`, 'Info');
       }
       if(pluginConfig[0].devices.length === 3) {
-         // creat a warning toast notification of the error
          homebridge.toast.info(`This process may take up to 3 minutes`, 'Info');
       }
 

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -1,11 +1,45 @@
-<link rel="stylesheet" href="css/style.css">
+<script>
+  (async () => {
+    // get the initial config from cmd4AdvantageAir config - this is an array potentially containing multiple config blocks
+    const pluginConfig = await homebridge.getPluginConfig();
+    const configSchema = await homebridge.getPluginConfigSchema();
 
+    if (!pluginConfig.length) {
+      pluginConfig.push({});
+    }
+    const configuration = pluginConfig[0];
+    configuration.devices = configuration.devices || [];
+
+    function createForm(configSchema, configuration) {
+      const configForm = homebridge.createForm(configSchema, configuration);
+      configForm.onChange(async (changes) => {
+        await homebridge.updatePluginConfig([changes]);
+      })
+    }
+    createForm(configSchema, configuration);
+  })();
+</script>
+
+<div class="card card-body">
+  <img src="images/AdvAir.png" alt="Advantage Air" width="150px" class="center-it cmd4Logo">
+  <h5 class="text-center"><b style="font-weight: 600;">Advantage Air Configuration Creator</b></h5>
+  <h6 class="text-center">This script will create the AdvantageAir configuration file for Cmd4 Plugin based on the info from your AdvantageAir system! </h6>
+  <br>
+  <div class="text-center">
+    <button id="ConfigCreatorButton" type="button" class="btn btn-primary">Config Creator</button>
+  </div>
+  <div class="form-group">
+    <label for="feedbackOutput">Feedback messages from ConfigCreator (read only)</label>
+    <input type="text" class="form-control" id="feedbackOutput" readonly>
+  </div>
+</div>
+
+<link rel="stylesheet" href="css/style.css">
 <div id="main" class="card card-body pb-5">
 
   <!-- start -->
   <div id="start">
-    <img src="images/AdvAir.png" alt="Advantage Air" width="150px" class="center-it cmd4Logo">
-    <h3 class="text-center">Welcome to <br> <b style="font-weight: 800;">Advantage Air Configuration Check</b></h3>
+    <h5 class="text-center"> <b style="font-weight: 600;">Advantage Air Configuration Check</b></h5>
     <h6 class="text-center">This plugin augments the Cmd4 Plugin for Advantage Air, primarily to keep your Advantage Air Cmd4 scripts up to date! </h6>
     <button id="checkInstallationButton" type="submit" class="btn btn-primary center-it mt-3">Check Configuration</button>
   </div>
@@ -20,7 +54,7 @@
                <span aria-hidden="true">&times;</span>
             </button>
          </div>
-         <div class="modal-body">
+         <div class="modal-body"
             <p>Modal body text goes here.</p>
          </div>
       </div>
@@ -33,5 +67,104 @@
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
 
 <!-- Main -->
-<script type="text/javascript" src="js/main.js?v=0.0.7"></script>
+<script type="text/javascript" src="js/main.js?v=0.0.7">
+</script>
 
+<script>
+  (async () => {
+    // get the initial config - this is an array potentially containing multiple config blocks
+    const pluginConfig = await homebridge.getPluginConfig();
+
+    AAIP2 = "";
+    AAname2 = "";
+    AAIP3 = "";
+    AAname3 = "";
+    feedback = "";
+
+    if (!pluginConfig.length) {
+      pluginConfig.push({});
+    }
+
+    // get the intial from the config and add it to the form
+    if (pluginConfig.length) {
+      if (pluginConfig[0].devices.length >= 1) {
+        AAIP = pluginConfig[0].devices[0].ipAddress;
+        AAname = pluginConfig[0].devices[0].name;
+      }
+      if (pluginConfig[0].devices.length >= 2) {
+        AAIP2 = pluginConfig[0].devices[1].ipAddress;
+        AAname2 = pluginConfig[0].devices[1].name;
+      }
+      if (pluginConfig[0].devices.length === 3) {
+        AAIP3 = pluginConfig[0].devices[2].ipAddress;
+        AAname3 = pluginConfig[0].devices[2].name;
+      }
+    }
+   
+
+
+    // watch for click events on the ConfigCreatorButton
+    document.querySelector('#ConfigCreatorButton').addEventListener('click', async () => {
+
+      // validate an ip was provided
+      if (pluginConfig[0].devices.length === 0) {
+        homebridge.toast.error(`No device defined yet. Please define at least 1 device and SAVE it.`, 'Error');
+        return;
+      }
+      if (AAIP === "undefined" || !AAIP) {
+        // create a error / red toast notification if the required input is not provided.
+        homebridge.toast.error('An ip address of your AdvantageAir system must be provided.', 'Error');
+        return;
+      }
+
+      // starting the request, show the loading spinner
+      homebridge.showSpinner();
+
+      // request key paths from the server
+      if(pluginConfig[0].devices.length === 1) {
+         // creat a warning toast notification of the error
+         homebridge.toast.info(`This process may take up to 1 minute`, 'Info');
+      }
+      if(pluginConfig[0].devices.length === 2) {
+         // creat a warning toast notification of the error
+         homebridge.toast.info(`This process may take up to 2 minutes`, 'Info');
+      }
+      if(pluginConfig[0].devices.length === 3) {
+         // creat a warning toast notification of the error
+         homebridge.toast.info(`This process may take up to 3 minutes`, 'Info');
+      }
+
+      try {
+        const response = await homebridge.request('/configcreator', {
+          ip: AAIP,
+          name: AAname,
+          ip2: AAIP2,
+          name2: AAname2,
+          ip3: AAIP3,
+          name3: AAname3,
+          feedback: feedback 
+        });
+
+        // update the ipform input with the response
+        document.querySelector('#feedbackOutput').value = response.feedback;
+
+        if(response.feedback.includes("ERROR")) {
+           // creat a red toast notification of the error
+           homebridge.toast.error(`${response.feedback}`, 'Error');
+           return;
+        } else if(response.feedback.includes("DONE")) {
+           // show a success toast notification
+           homebridge.toast.success('ConfigCreator completed!', 'Success');
+           return;
+        } else {
+           homebridge.toast.error(`ConfigCreator did not run!`, 'Error');
+        }
+      } catch (e) {
+        homebridge.toast.error(e.error, e.message);
+      } finally {
+        // remember to un-hide the spinner
+        homebridge.hideSpinner();
+      }
+    });
+  })();
+</script>

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -7,7 +7,7 @@
     <button id="ConfigCreatorButton" type="button" class="btn btn-primary">Config Creator</button>
   </div>
   <div>
-    <input type="checkbox" id="fanSetup" checked> "Fan" setup as "FanSwitch"
+    <input type="checkbox" id="fanSetup"> "Fan" setup as "FanSwitch"
   </div>
   <div class="form-group">
     <label for="feedbackOutput">Feedback messages from ConfigCreator (read only)</label>

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -1,25 +1,3 @@
-<script>
-  (async () => {
-    // get the initial config from cmd4AdvantageAir config - this is an array potentially containing multiple config blocks
-    const pluginConfig = await homebridge.getPluginConfig();
-    const configSchema = await homebridge.getPluginConfigSchema();
-
-    if (!pluginConfig.length) {
-      pluginConfig.push({});
-    }
-    const configuration = pluginConfig[0];
-    configuration.devices = configuration.devices || [];
-
-    function createForm(configSchema, configuration) {
-      const configForm = homebridge.createForm(configSchema, configuration);
-      configForm.onChange(async (changes) => {
-        await homebridge.updatePluginConfig([changes]);
-      })
-    }
-    createForm(configSchema, configuration);
-  })();
-</script>
-
 <div class="card card-body">
   <img src="images/AdvAir.png" alt="Advantage Air" width="150px" class="center-it cmd4Logo">
   <h5 class="text-center"><b style="font-weight: 600;">Advantage Air Configuration Creator</b></h5>
@@ -74,16 +52,28 @@
   (async () => {
     // get the initial config - this is an array potentially containing multiple config blocks
     const pluginConfig = await homebridge.getPluginConfig();
+    const configSchema = await homebridge.getPluginConfigSchema();
 
+    if (!pluginConfig.length) {
+      pluginConfig.push({});
+    }
+    const configuration = pluginConfig[0];
+    configuration.devices = configuration.devices || [];
+
+    function createForm(configSchema, configuration) {
+      const configForm = homebridge.createForm(configSchema, configuration);
+      configForm.onChange(async (changes) => {
+        await homebridge.updatePluginConfig([changes]);
+      })
+    }
+
+    AAIP = "";
+    AAname = "";
     AAIP2 = "";
     AAname2 = "";
     AAIP3 = "";
     AAname3 = "";
     feedback = "";
-
-    if (!pluginConfig.length) {
-      pluginConfig.push({});
-    }
 
     // get the intial from the config and add it to the form
     if (pluginConfig.length) {
@@ -95,22 +85,22 @@
         AAIP2 = pluginConfig[0].devices[1].ipAddress;
         AAname2 = pluginConfig[0].devices[1].name;
       }
-      if (pluginConfig[0].devices.length === 3) {
+      if (pluginConfig[0].devices.length >= 3) {
         AAIP3 = pluginConfig[0].devices[2].ipAddress;
         AAname3 = pluginConfig[0].devices[2].name;
       }
     }
-   
-
 
     // watch for click events on the ConfigCreatorButton
     document.querySelector('#ConfigCreatorButton').addEventListener('click', async () => {
 
-      // validate an ip was provided
+
       if (pluginConfig[0].devices.length === 0) {
         homebridge.toast.error(`No device defined yet. Please define at least 1 device and SAVE it.`, 'Error');
         return;
       }
+
+      // validate an ip was provided
       if (AAIP === "undefined" || !AAIP) {
         // create a error / red toast notification if the required input is not provided.
         homebridge.toast.error('An ip address of your AdvantageAir system must be provided.', 'Error');
@@ -166,5 +156,6 @@
         homebridge.hideSpinner();
       }
     });
+    createForm(configSchema, configuration);
   })();
 </script>

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -52,6 +52,7 @@ class UiServer extends HomebridgePluginUiServer
       console.log('AA system ip2 address:', payload.name2);
       console.log('AA system ip3 address:', payload.ip3);
       console.log('AA system ip3 address:', payload.name3);
+      console.log('Fan setup instruction:', payload.fanSetup);
 
       try {
          const AdvAir_shPath = this.getGlobalNodeModulesPathForFile( this.ADVAIR_SH );
@@ -59,7 +60,7 @@ class UiServer extends HomebridgePluginUiServer
 
          //This spawns a child process which runs a bash script
          const spawnSync = require('child_process').spawnSync;
-         let FeedBack = spawnSync(ConfigCreator_shPath, [payload.ip, payload.name, payload.ip2, payload.name2, payload.ip3, payload.name3, AdvAir_shPath], {encoding: 'utf8'});
+         let FeedBack = spawnSync(ConfigCreator_shPath, [payload.ip, payload.name, payload.ip2, payload.name2, payload.ip3, payload.name3,payload.fanSetup,  AdvAir_shPath], {encoding: 'utf8'});
          let feedback = `${ FeedBack.stdout.replace(/\n*$/, "")}`
 
          // return data to the ui
@@ -664,7 +665,7 @@ class UiServer extends HomebridgePluginUiServer
                }
                else if ( accessory.type.match( /Switch/ ) )
                {
-                   if ( ! ( accessory.displayName.match( /Aircon Fan/ ) ||
+                   if ( ! ( accessory.displayName.match( / Fan$/ ) ||
                     state_cmd_suffix.match( /z[0-9][0-9]/ ) 
                       )       
                    )

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -64,9 +64,6 @@ class UiServer extends HomebridgePluginUiServer
 
          // return data to the ui
          return {
-            AAIP: payload.ip,
-            AAIP2: payload.ip2,
-            AAIP3: payload.ip3,
             feedback: feedback
          }
       }

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -46,12 +46,9 @@ class UiServer extends HomebridgePluginUiServer
    }
 
    async ConfigCreator(payload) {
-      console.log('AA system ip address:', payload.ip);
-      console.log('AA system ip address:', payload.name);
-      console.log('AA system ip2 address:', payload.ip2);
-      console.log('AA system ip2 address:', payload.name2);
-      console.log('AA system ip3 address:', payload.ip3);
-      console.log('AA system ip3 address:', payload.name3);
+      if (payload.ip !== "") {console.log('Processing AA system:', payload.name,payload.ip)};
+      if (payload.ip2 !== "") {console.log('Processing AA system:', payload.name2,payload.ip2)};
+      if (payload.ip3 !== "") {console.log('Processing AA system:', payload.name3,payload.ip3)};
       console.log('Fan setup instruction:', payload.fanSetup);
 
       try {


### PR DESCRIPTION
---
name: Pull Request
about: Add an improvement to homebridge-cmd4-AdvantageAir.
title: "Running ConfigCreator from customUi"
labels: Improvement
assignees: mitch7391

---

<!-- Provide a general summary in the Title above -->
The first version of ConfigCreator was run from Terminal and required an intensive `find` command and super user password.   ConfigCreator has now been brought into homebridge-ui environment.  It no longer requires the intensive `find` command nor require any super user password. It is running a lot faster too.

**Is your pull request related to a problem or a new feature? Please describe:**
<!-- A clear and concise description of what the problem is. E.g. "Mitch, there needs to be a button to buy you a coffee!" -->
It is a major improvement to the existing tool.

**Describe the solution you'd have implemented:**
<!-- A clear and concise description of what you your pull request is for. Explain the technical solution you have provided and how it addresses the issue. -->
1. Modified `config.schema.json` file to allow user input of the AdvantageAir devices.
2. Added codes to `index.html` to include `ConfigCreator` button and integrate the `config.schema.json`, so that both can be displayed on a single `Setting` page.
3. Added codes to `server.js` to allow the running of ConfigCreator.sh bash script within the homebridge-ui enviornment.
4. Modified ConfigCreator.sh to suite - delete the use of `find` command, removed interactive user input prompts, etc.

**Do your changes pass local testing:**
- [x] Yes  Tested successfully on RPi ad Mac.
<!-- If unclear, I can update these afterwards. -->

**Additional context:**
<!-- Add any other context or screenshots about the pull request here. -->
For the first time user, make sure that the AdvantageAir device(s) is/are defined and saved in cmd4-AdvantagaAir config.  This can be done on the `AdvantageAir Device Settings` section of the `SETTING` page.

Once the AdvantageAir device(s) is/are defined (note that only a maximum of 3 devices can be processed by ConfigCreator) and saved, click the `CONFIG CREATOR` button to auto-create the Cmd4 configuration file required to run the cmd4-AdvantageAir plugin.  Make sure you check the checkbox if you want the fan to be setup as `FanSwitch` before you click the `CONFIG CREATOR` button.

Once the configuration is created, you can then use the `CHECK CONFIGURATION` button to check whether the configuration meets all the requirement. 

You can always inspect or edit the configuration created in Cmd4 (not cmd4-AdvantageAir) JASON Config editor if you want.

A sneak peep of the `SETTING` page is shown below:

![image](https://user-images.githubusercontent.com/96530237/184627116-7cca5662-9b28-4025-968f-5727971c92d2.png)

<!-- Click the "Preview" tab before you submit to ensure the formatting is correct. -->
