### PR TITLE
[Pull Request] Run Check Configuration from Command Line

### DIFF
--- a/CheckConfig.js
+++ b/CheckConfig.js
@@ -1,0 +1,634 @@
+const fs = require('fs')
+const chalk = require('chalk')
+const commandExistsSync = require( "command-exists" ).sync;
+
+// Parse the args
+var args = process.argv.slice(2);
+const ADVAIR_SH_PATH = args[0] || "/usr/local/lib/node_modules/homebridge-cmd4-advantageair/AdvAir.sh";
+const homebridgeConfigPath = args[1] || "/var/lib/homebridge/config.json";
+
+let listOfConstants = { };
+var debug = false;
+
+consoleLog(`ADVAIR_path=${ADVAIR_SH_PATH}`)
+consoleLog(`configJsonPath=${homebridgeConfigPath}`)
+
+checkInstallationButtonPressed( true )
+
+function consoleLog( msg )
+{
+   if ( debug ) { 
+      console.log( msg );
+   }
+}
+
+function message( data )
+{
+   console.log( data );
+}
+
+function checkQueueTypesForQueue( queueTypes, queue )
+{
+   for ( let queueTypesIndex = 0; queueTypesIndex < queueTypes.length; queueTypesIndex++ )
+   {
+      let entry = queueTypes[ queueTypesIndex ];
+      if ( entry.queue == queue )
+      {
+         if ( entry.queueType == "WoRm2" )
+         {
+            return(
+            { rc: true,
+              message: `passed`
+            });
+         }
+         return(
+         { rc: false,
+           message: `queue ${ queue } queueType is not WoRm2. Please change to Worm2.`
+         });
+      }
+   }
+
+   return(
+   { rc: false,
+      message: `No matching queue: "${ queue }" in queueTypes`
+   });
+}
+
+// Cmd4 has the ability to allow constants which could be used for the IP
+function processConstants( constantsArgArray )
+{
+   //
+   // Check #8A
+   // Constants must be an Array
+   //
+   consoleLog( `Check #8A` );
+   if ( ! Array.isArray ( constantsArgArray ) )
+   {
+      message( chalk.red( `ERROR: Constants must be an array of { "key": "\${SomeKey}", "value": "some replacement string" }` ) )
+      return false;
+   }
+   // Iterate over the groups of key/value constants in the array.
+   // Note: DO NOT USE: forEach as javascript continues after a return!
+   for ( let argIndex = 0; argIndex < constantsArgArray.length; argIndex++ )
+   {
+      let argEntry = constantsArgArray[ argIndex ];
+
+      if ( argEntry.key == undefined )
+      {
+         //
+         // Check #8B
+         // key must be defined
+         //
+         consoleLog( `Check #8B` );
+         message( chalk.red( `ERROR: Constant definition at index: "${ argIndex }" has no "key":` ) )
+         return false;
+      }
+
+      if ( argEntry.value == undefined )
+      {
+         //
+         // Check #8c
+         // value must be defined
+         //
+         consoleLog( `Check #8C` );
+         message( chalk.red( `ERROR: Constant definition at index: "${ argIndex }" has no "value":` ) )
+         return false;
+      }
+
+      let keyToAdd = argEntry.key;
+      let valueToAdd = argEntry.value;
+      if ( ! keyToAdd.startsWith( "${" ) )
+      {
+         //
+         // Check #8D
+         // key must start with ${
+         //
+         consoleLog( `Check #8D` );
+         message( chalk.red( `ERROR: Constant definition for: "${ keyToAdd }" must start with "\${" for clarity.` ) )
+         return false;
+      }
+
+      if ( ! keyToAdd.endsWith( "}" ) )
+      {
+         //
+         // Check #8E
+         // key must end with }
+         //
+         consoleLog( `Check #8E` );
+         message( chalk.red( `ERROR: Constant definition for: "${ keyToAdd }" must end with "}" for clarity.` ) )
+         return false;
+      }
+
+      // remove any leading and trailing single quotes
+      // so that using it for replacement will be easier.
+      valueToAdd.replace(/^'/, "")
+      valueToAdd.replace(/'$/, "")
+
+      if ( debug )
+         console.log( chalk.cyan( `CheckConfig keyToAdd:${keyToAdd} valueToAdd:${valueToAdd}` ) );
+
+      listOfConstants[ keyToAdd ] = valueToAdd;
+   }
+
+   return true;
+}
+
+function replaceConstantsInString( orig )
+{
+   let finalAns = orig;
+
+   for ( let key in listOfConstants )
+   {
+      let replacementConstant = listOfConstants[ key ];
+
+      if ( debug )
+         console.log( chalk.cyan( `INFO: replacing key: ${ key } with: ${ replacementConstant }` ) );
+
+      finalAns = finalAns.replace( key, replacementConstant );
+   }
+   return finalAns;
+}
+
+function updateConfigFirstTime( firstTime )
+{
+   //
+   // Check #1
+   // See if the config.json file exists
+   //
+   consoleLog( `Check #1` );
+   let configFile = homebridgeConfigPath;
+
+   if ( configFile == undefined )
+   {
+      message( chalk.red( `ERROR: No config.json found or specified` ) )
+      return false;
+   }
+
+   if ( ! fs.existsSync( configFile ) )
+   {
+      if ( ! firstTime )
+      {
+         message( chalk.red( `ERROR: No ${ configFile } found or specified` ) )
+      }
+
+      return false;
+   }
+
+   // Open the config.json file for reading
+   let config_in = fs.readFileSync( configFile, 'utf8' );
+
+   //
+   // Check #2
+   // Convert the config.json into a json type
+   // This can throw an Error so catch it.
+   consoleLog( `Check #2` );
+   try {
+      this.config = JSON.parse( config_in );
+   } catch ( e )
+   {
+      if ( ! firstTime )
+      {
+         message( chalk.red( `ERROR: Parse config.json failed: ${ e }` ) )
+      }
+      return false;
+   }
+
+   let cmd4AdvantageAirConfig = this.config.platforms.find( platform => platform[ "Cmd4AdvantageAir" ] !== null );
+
+   if ( cmd4AdvantageAirConfig && cmd4AdvantageAirConfig.debug )
+   {
+      console.log( `Setting debug for Cmd4AdvantageAir` );
+      debug = cmd4AdvantageAirConfig.debug;
+   }
+
+   return true;
+}
+
+
+// There is nothing really to differentiate a regular Cmd4 Accessory for that of
+// an Advantage Air
+//
+function isAccessoryAnAdvAir( accessory )
+{
+   if ( accessory.manufacturer && accessory.manufacturer.match( /Advantage Air/ ) )
+      return true;
+
+   // Trigger off of the state_cmd, if it exists
+   if ( accessory.state_cmd != undefined )
+   {
+      // The old zone script
+      if ( accessory.state_cmd.match( /ezone.sh/ ) )
+         return true;
+      // The old zones script
+      if ( accessory.state_cmd.match( /zones.sh/ ) )
+         return true;
+      // The new AdvAir
+      if ( accessory.state_cmd.match( /AdvAir.sh/ ) )
+         return true;
+   }
+
+   return false;
+}
+
+function checkInstallationButtonPressed( )
+{
+   // The read in config.json in JSON format
+
+   if ( debug )
+      console.log( chalk.cyan( `INFO: CheckConfig is now in the process of checking the config.json` ) );
+
+   // Update the config, this is not the first time
+   // return if it fails. As this is not the First time, it will
+   // error if need be.
+   if ( updateConfigFirstTime( false ) == false )
+      return;
+
+   //
+   // Check #3
+   // Check that jq is installed.
+   consoleLog( `Check #3` );
+   if ( ! commandExistsSync( "jq" ) )
+   {
+      message( chalk.red( `ERROR: jq is required globally and not installed.` ) )
+      return;
+   }
+
+   //
+   // Check #4
+   // Check that curl is installed.
+   consoleLog( `Check #4` );
+   if ( ! commandExistsSync( "curl" ) )
+   {
+      message( chalk.red( `ERROR: curl is required globally and not installed.` ) )
+      return;
+   }
+
+   //
+   // Check #5 is already done before calling this CheckConfig.js    
+   // Check #5A
+   // Find Node modules
+   //
+   // console.log( `Check #5A` );
+   // let node_modules = getGlobalNodeModulesPathForFile( "" );
+   // if ( node_modules == null )
+   // {
+   //    message( chalk.red( `ERROR: Could not determine where node_modules is installed globally.` ) )
+   //    return;
+   // }
+   //
+   // Check #5B
+   // See if Cmd4 is installed from node_modules
+   //
+   // fileToFind = "/homebridge-cmd4/index.js";
+   // let cmd4Index = getGlobalNodeModulesPathForFile( fileToFind )
+   // if ( cmd4Index == null )
+   // {
+   //    message( chalk.red( `ERROR: Cmd4 Plugin not installed` ) )
+   //    return;
+   // }
+
+   //
+   // Check #6
+   // See if our AdvAir.sh script is present
+   //
+   // Create the path to the cmd4MyAir.sh from node_modules
+   consoleLog( `Check #6` );
+   let ourScript =  ADVAIR_SH_PATH
+   if ( ourScript == null )
+   {
+      message( chalk.red( `ERROR: No AdvAir.sh script present. Looking for: <Your Global node_modules Path>${ this.ADVAIR_SH }` ) )
+      return;
+   }
+
+   let cmd4AccessoriesFound = false;
+   let advantageAirAccessoriesFound = [];
+   let cmd4QueueTypesFound = [];
+   let retVal = { };
+   // Iterate over the elements in the array.
+   // Note: DO NOT USE: forEach as javascript continues after a return!
+   for ( let entryIndex = 0; entryIndex < this.config.platforms.length; entryIndex++ )
+   {
+      let entry = this.config.platforms[ entryIndex];
+
+      if ( debug )
+         console.log( chalk.cyan( `INFO: CheckConfig is checking Platform entry ${ entry.platform }` ) );
+
+      //
+      // Check #7
+      // See if any Cmd4 accessories are defined in config.json
+      //
+      consoleLog( `Check #7` );
+      if ( entry.platform != "Cmd4" )
+         continue;
+
+      cmd4AccessoriesFound = true;
+
+      //
+      // Check #18
+      // See if there are any accessory queues defined
+      //
+      consoleLog( `Check #18` );
+      if ( entry.queueTypes != undefined )
+      {
+         //
+         // Check #19
+         // queueTypes must be an array
+         //
+         consoleLog( `Check #19` );
+         if ( ! Array.isArray( entry.queueTypes ) )
+         {
+            message( chalk.red( `ERROR: queueTypes is not an Array` ) )
+            return;
+         }
+
+         // Iterate over the elements in the array.
+         // Note: DO NOT USE: forEach as javascript continues after a return!
+         for ( let queueTypesIndex = 0; queueTypesIndex < entry.queueTypes.length; queueTypesIndex++ )
+         {
+            let queueTypeEntry = entry.queueTypes[ queueTypesIndex ];
+
+            // Need to append each one
+            retVal =  checkQueueTypesForQueue( cmd4QueueTypesFound, queueTypeEntry.queue );
+            if ( retVal.rc == true )
+            // if ( cmd4QueueTypesFound.find( queueTypeEntry ) )
+            {
+               //
+               // Check #20
+               // Duplicate queue
+               //
+               consoleLog( `Check #20` );
+               message( chalk.red( `ERROR: Duplicate queue found: ${ queueTypeEntry.queue }` ) )
+               return;
+            }
+            cmd4QueueTypesFound.push( queueTypeEntry );
+         }
+      }
+
+      //
+      // Check #8
+      // Process Constants
+      //
+      consoleLog( `Check #8` );
+      if ( entry.constants != undefined )
+         if ( processConstants( entry.constants ) == false )
+            return;
+
+      // Iterate over the elements in the array.
+      // Note: DO NOT USE: forEach as javascript continues after a return!
+      for ( let accessoryIndex = 0; accessoryIndex < entry.accessories.length; accessoryIndex++ )
+      {
+         let accessory = entry.accessories[ accessoryIndex ];
+
+         if ( debug )
+            console.log(  chalk.cyan( `INFO: CheckConfig is checking accessory ${ accessory.name }` ) );
+
+         //
+         // Check #9
+         // See if any Advantage Air accessories are defined in config.json
+         //
+         consoleLog( `Check #9` );
+         if ( ! isAccessoryAnAdvAir( accessory ) )
+            continue;
+
+         //
+         // Check #10
+         // See if any Advantage Air accessory has a defined name
+         //
+         consoleLog( `Check #10` );
+
+         if ( debug )
+            console.log( chalk.cyan( `INFO: CheckConfig is checking accessory ${ accessory.name }` ) );
+
+         if ( accessory.name == undefined )
+         {
+            message( chalk.red( `ERROR: Accessory at index: ${ entryIndex } accessory.name is undefined` ) )
+            return;
+         }
+
+         //
+         // Check #11
+         // See if any Advantage Air accessory has a defined displayName
+         //
+         consoleLog( `Check #11` );
+
+         if ( debug )
+            console.log( chalk.cyan( `INFO: CheckConfig is checking accessory ${ accessory.name } for displayName` ) );
+
+         if ( accessory.displayName == undefined )
+         {
+            message( chalk.red( `ERROR: Accessory at index: ${ entryIndex } "${ accessory.name }" has no displayName` ) )
+            return;
+         }
+
+         //
+         // Check #12
+         // Polling is done by displayName, It cannot already exist.
+         //
+         consoleLog( `Check #12` );
+
+         if ( debug )
+            console.log( chalk.cyan( `INFO: CheckConfig is Checking accessory ${ accessory.displayName } for duplicate displayName` ) );
+
+         if ( advantageAirAccessoriesFound.find( ( displayName ) => displayName == accessory.displayName ) )
+         {
+            message( chalk.red( `ERROR: Accessory: "${ accessory.displayName }"'s displayName is defined twice` ) )
+            return;
+         }
+
+
+         // Add it to the Array
+         advantageAirAccessoriesFound.push( accessory.displayName );
+
+         if ( debug )
+            console.log( chalk.cyan( `INFO: CheckConfig is Checking Advantage Air accessory ${ accessory.displayName }` ) );
+
+         //
+         // Check #13
+         // The state_cmd must be defined for the Air accessory
+         //
+         consoleLog( `Check #13` );
+         if ( accessory.state_cmd == undefined )
+         {
+            message( chalk.red( `ERROR: No state_cmd for: "${ accessory.displayName }"` ) )
+            return;
+         }
+
+         //
+         // Check #14
+         // See if the state_cmd does not match the cmd4AdvAir.sh
+         //
+         consoleLog( `Check #14` );
+         if ( ! accessory.state_cmd.match( ourScript ) )
+         {
+            message( chalk.red( `ERROR: Invalid state_cmd for: "${ accessory.displayName }". It should be:\n${ ourScript }` ) )
+            return;
+         }
+
+         //
+         // Check #15
+         // See if the state_cmd_suffix is defined for the Air accessory
+         // It must have at least an IP
+         consoleLog( `Check #15` );
+         if ( accessory.state_cmd_suffix == undefined )
+         {
+            message( chalk.red( `ERROR: No state_cmd_suffix for: "${ accessory.displayName }". It must at least contain an IP.` ) )
+            return;
+         }
+
+         if ( debug )
+            console.log( chalk.cyan( `INFO: Calling replaceConstantsInString` ) );
+
+         let state_cmd_suffix = replaceConstantsInString(  accessory.state_cmd_suffix );
+
+         if ( debug )
+            console.log( chalk.cyan( `INFO: after replaceConstantsInString state_cmd_suffix=${ state_cmd_suffix }` ) );
+
+         //
+         // Check #16
+         // The state_cmd_suffix must have an IP for the Air accessory
+         //
+         consoleLog( `Check #16` );
+         if ( ! state_cmd_suffix.match( /[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*/ ) )
+         {
+            message( chalk.red( `ERROR: state_cmd_suffix has no IP for: "${ accessory.displayName }" state_cmd_suffix: ${ state_cmd_suffix }` ) )
+            return;
+         }
+
+         //
+         // Check #17A
+         // The state_cmd_suffix must have a zone or timer for an Air accessory
+         // except a Fan or a Thermostat or a GarageDoorOpener
+         //
+         consoleLog( `Check #17A` );
+         if ( ! accessory.type.match( /^Fan/ ) &&
+              ! accessory.type.match( /^Thermostat/ ) &&
+              ! accessory.type.match( /^GarageDoorOpener/ ) )
+         {
+            if ( accessory.type.match( /Lightbulb/ ) )
+            {
+                if ( ! ( state_cmd_suffix.match( /z[0-9][0-9]/ ) ||
+                 state_cmd_suffix.match( /timer/ ) ||
+                 state_cmd_suffix.match( /'light:/ )
+                   )
+                )
+                {
+                   message( chalk.red( `ERROR: The state_cmd_suffix for: "${ accessory.displayName }" requires a zone (e.g. z01) if used for zone control, requires 'timer' (without quotes) if being used as the 'Aircon Timer' or requires 'light:${ accessory.displayName }' if being used as a MyPlace Light.` ) )
+                   return;
+                }
+            }
+            else if ( accessory.type.match( /Switch/ ) )
+            {
+                if ( ! ( accessory.displayName.match( / Fan$/ ) ||
+                 state_cmd_suffix.match( /z[0-9][0-9]/ ) 
+                   )       
+                )
+                {
+                   message( chalk.red( `ERROR: state_cmd_suffix has no zone for: "${ accessory.displayName }"` ) )
+                   return;                   
+                }                 
+            }               
+            else
+            {
+               if ( ! state_cmd_suffix.match( /z[0-9][0-9]/ ) )
+               {
+                   message( chalk.red( `ERROR: state_cmd_suffix has no zone for: "${ accessory.displayName }"` ) )
+                   return;
+               }
+            }
+         }
+
+         //
+         // Check #17B
+         // The state_cmd_suffix must have a 'thing:NAME' for GarageDoorOpener
+         //
+         consoleLog( `Check #17B` );
+         if ( accessory.type.match( /GarageDoorOpener/ ) )
+         {
+            if ( ! state_cmd_suffix.match( /'thing:/ ) )
+            {
+                message( chalk.red( `ERROR: The state_cmd_suffix for: "${ accessory.displayName }" requires 'thing:${ accessory.displayName }'.` ) )
+                return;
+            }               
+         }
+
+         //
+         // Check #21
+         // See if there is a queue defined
+         //
+         consoleLog( `Check #21`);
+         if ( accessory.queue == undefined )
+         {
+            message( chalk.red( `ERROR: No queue defined for: "${ accessory.displayName }"` ) )
+            return;
+         }
+
+         //
+         // Check #22
+         // queue name must be an string
+         //
+         consoleLog( `Check #22`);
+         if ( typeof accessory.queue != "string" )
+         {
+            message( chalk.red( `ERROR: queue for: "${ accessory.displayName }" is not a string` ) )
+            return;
+         }
+
+         retVal = checkQueueTypesForQueue( cmd4QueueTypesFound, accessory.queue );
+         // Check #23
+         // queue must be defined in queueTypes
+         consoleLog( `Check #23`);
+         if ( retVal.rc == false )
+         {
+            message( chalk.red( `ERROR: For: "${ accessory.displayName }" ${ retVal.message }` ) )
+            return;
+         }
+
+         // Check #24 Polling must be defined for AdvAir accessories
+         consoleLog( `Check #24`);
+         if ( ! accessory.polling ||
+              ( typeof accessory.polling == "boolean" && accessory.polling != true &&
+              ! Array.isArray( accessory.polling) ) )
+         {
+            message( chalk.red( `ERROR: Polling for: "${ accessory.displayName }" is not an Array or Boolean` ) )
+            return;
+         }
+      }
+   }
+
+   //
+   // Check #32
+   // See if any Cmd4 accessories are defined in config.json
+   //
+   consoleLog( `Check #32`);
+   if ( cmd4AccessoriesFound == false )
+   {
+      message( chalk.red( `ERROR: No Cmd4 Accessories found` ) )
+      return;
+   }
+
+   //
+   // Check #33
+   // See if any Advantage Air accessories are defined in config.json
+   //
+   consoleLog( `Check #33`);
+   if ( advantageAirAccessoriesFound.length == 0 )
+   {
+      message( chalk.red( `ERROR: No Advantage Air Accessories found` ) )
+      return;
+   }
+
+   //
+   // Check #34
+   // See if any queueTypes were defined
+   // ( Most likely an earlier failure will succeed this one )
+   //
+   consoleLog( `Check #34`);
+   if ( cmd4QueueTypesFound == null )
+   {
+      message( chalk.red( `ERROR: No Cmd4 Queue Types were defined for Advantage Air Accessories` ) )
+      return;
+   }
+
+   // PASS !
+   message( chalk.green( chalk.bold ( `PASSED` ) ) )
+}

--- a/CheckConfig.sh
+++ b/CheckConfig.sh
@@ -1,0 +1,322 @@
+#!/bin/bash
+#
+# This script is to check the Cmd4 configuration file for cmd4-advantageair plugin
+#
+# Usage ./CheckConfig.sh                                                                   
+# 
+
+# define the possible names for cmd4 platform
+cmd4Platform1="\"platform\": \"Cmd4\""
+cmd4Platform2="\"platform\": \"homebridge-cmd4\""
+
+# define some file variables
+homebridgeConfigJson=""           # homebridge config.json
+configJson="config.json.copy"     # a working copy of homebridge config.json
+
+# fun color stuff
+BOLD=$(tput bold)
+TRED=$(tput setaf 1)
+#TGRN=$(tput setaf 2)
+TYEL=$(tput setaf 3)
+TPUR=$(tput setaf 5)
+TLBL=$(tput setaf 6)
+TNRM=$(tput sgr0)
+
+function readHomebridgeConfigJson()
+{
+         INPUT=""
+         homebridgeConfigJson=""
+         getHomebridgeConfigJsonPath
+         if [ "${fullPath}" != "" ]; then homebridgeConfigJson="${fullPath}"; fi 
+ 
+         # if no config.json file found, ask user to input the full path
+         if [ -z "${homebridgeConfigJson}" ]; then
+            homebridgeConfigJson=""
+            echo ""
+            echo "${TPUR}WARNING: No Homebridge config.json file located by the script!${TNRM}"
+            echo ""
+            until [ -n "${INPUT}" ]; do
+               echo "${TYEL}Please enter the full path of your Homebridge config.json file,"
+               echo "The config.json path should be in the form of /*/*/*/config.json ${TNRM}"
+               read -r -p "${BOLD}> ${TNRM}" INPUT
+               if [ -z "${INPUT}" ]; then
+                  echo "${TPUR}WARNING: No Homebridge config.json file specified"
+                  cleanUp
+                  exit 1
+               elif expr "${INPUT}" : '[./a-zA-Z0-9]*/config.json$' >/dev/null; then
+                  if [ -f "${INPUT}" ]; then
+                     homebridgeConfigJson="${INPUT}"
+                     break
+                  else
+                     echo ""
+                     echo "${TPUR}WARNING: No such file exits!${TNRM}"
+                     echo ""
+                     INPUT=""
+                  fi
+               else
+                  echo ""
+                  echo "${TPUR}WARNING: Wrong format for file path for Homebridge config.json!${TNRM}"
+                  echo ""
+                  INPUT=""
+               fi
+           done
+         fi
+         if [ -f "${homebridgeConfigJson}" ]; then
+            if [ -z "${INPUT}" ]; then
+               echo "${TLBL}INFO: The Homebridge config.json found: ${homebridgeConfigJson}${TNRM}"
+               echo ""
+            else
+               echo ""
+               echo "${TLBL}INFO: The Homebridge config.json specified: ${homebridgeConfigJson}${TNRM}"
+               echo ""
+            fi
+            # expand the json just in case it is in compact form
+            jq --indent 4 '.' "${homebridgeConfigJson}" > "${configJson}"
+            checkForPlatformCmd4InHomebridgeConfigJson
+            if [ -z "${validFile}" ]; then
+               echo ""
+               echo "${TRED}ERROR: no Cmd4 Config found in \"${homebridgeConfigJson}\"! Please ensure that Homebridge-Cmd4 plugin is installed${TNRM}"
+               cleanUp
+               exit 1
+            fi
+         fi
+}
+
+
+function getGlobalNodeModulesPathForFile()
+{
+   file="$1"
+   fullPath=""    
+
+   for ((tryIndex = 1; tryIndex <= 6; tryIndex ++)); do
+      case $tryIndex in  
+         1)
+            foundPath=$(find /var/lib/hoobs "${file}" 2>&1|grep -v find|grep -v System|grep -v cache|grep node_modules|grep cmd4-advantageair|grep "${file}") 
+            fullPath=$(echo "${foundPath}"|head -n 1)
+            if [ -f "${fullPath}" ]; then
+               return
+            fi
+         ;;
+         2)
+            foundPath=$(npm root -g)
+            fullPath="${foundPath}/homebridge-cmd4-advantageair/${file}"
+            if [ -f "${fullPath}" ]; then
+               return    
+            fi
+         ;;
+         3)
+            fullPath="/var/lib/node_modules/homebridge-cmd4-advantageair/${file}"
+            if [ -f "${fullPath}" ]; then
+               return   
+            fi
+         ;;
+         4)
+            fullPath="/usr/local/lib/node_modules/homebridge-cmd4-advantageair/${file}"
+            if [ -f "${fullPath}" ]; then
+               return
+            fi
+         ;;
+         5)
+            fullPath="/usr/lib/node_modules/homebridge-cmd4-advantageair/${file}"
+            if [ -f "${fullPath}" ]; then
+               return
+            fi
+         ;;
+         6)
+            fullPath="/opt/homebrew/lib/node_modules/homebridge-cmd4-advantageair/${file}"
+            if [ -f "${fullPath}" ]; then
+               return
+            fi
+         ;;
+      esac
+   done
+}
+
+function getHomebridgeConfigJsonPath()
+{
+   fullPath=""
+
+   for ((tryIndex = 1; tryIndex <= 6; tryIndex ++)); do
+      case $tryIndex in
+         1)
+            # HOOBS has multiple bridges and hence has multiple config.json files, need to scan all config.json file for the Cmd4 plugin
+            foundPath=$(find /var/lib/hoobs -name config.json 2>&1|grep -v find|grep -v System|grep -v cache|grep -v hassio|grep -v node_modules|grep config.json)
+            noOfInstances=$(echo "${foundPath}"|wc -l)
+            for ((i = 1; i <= noOfInstances; i ++)); do
+               fullPath=$(echo "${foundPath}"|sed -n "${i}"p)
+               if [ -f "${fullPath}" ]; then
+                  checkForCmd4PlatformNameInFile   
+                  if [ -n "${cmd4PlatformNameFound}" ]; then 
+                     return
+                  else
+                     fullPath=""
+                  fi
+               fi
+            done
+         ;;
+         2)
+            fullPath="/var/lib/homebridge/config.json"
+            if [ -f "${fullPath}" ]; then
+               return
+            fi
+         ;;
+         3)
+            fullPath="$HOME/.homebridge/config.json"
+            if [ -f "${fullPath}" ]; then
+               return
+            fi
+         ;;
+         4)
+            foundPath=$(find /usr/local/lib -name config.json 2>&1|grep -v find|grep -v System|grep -v cache|grep -v hassio|grep -v node_modules|grep config.json)
+            noOfInstances=$(echo "${foundPath}"|wc -l)
+            for ((i = 1; i <= noOfInstances; i ++)); do
+               fullPath=$(echo "${foundPath}"|sed -n "${i}"p)
+               if [ -f "${fullPath}" ]; then
+                  checkForCmd4PlatformNameInFile   
+                  if [ -n "${cmd4PlatformNameFound}" ]; then 
+                     return
+                  else
+                     fullPath=""
+                  fi
+               fi
+            done
+         ;;
+         5)
+            foundPath=$(find /usr/lib -name config.json 2>&1|grep -v find|grep -v System|grep -v cache|grep -v hassio|grep -v node_modules|grep config.json)
+            noOfInstances=$(echo "${foundPath}"|wc -l)
+            for ((i = 1; i <= noOfInstances; i ++)); do
+               fullPath=$(echo "${foundPath}"|sed -n "${i}"p)
+               if [ -f "${fullPath}" ]; then
+                  checkForCmd4PlatformNameInFile   
+                  if [ -n "${cmd4PlatformNameFound}" ]; then 
+                     return
+                  else
+                     fullPath=""
+                  fi
+               fi
+            done
+         ;;
+         6)
+            foundPath=$(find /var/lib -name config.json 2>&1|grep -v find|grep -v hoobs|grep -v System|grep -v cache|grep -v hassio|grep -v node_modules|grep config.json)
+            noOfInstances=$(echo "${foundPath}"|wc -l)
+            for ((i = 1; i <= noOfInstances; i ++)); do
+               fullPath=$(echo "${foundPath}"|sed -n "${i}"p)
+               if [ -f "${fullPath}" ]; then
+                  checkForCmd4PlatformNameInFile   
+                  if [ -n "${cmd4PlatformNameFound}" ]; then 
+                     return
+                  else
+                     fullPath=""
+                  fi
+               fi
+            done
+         ;;
+      esac
+   done
+}
+
+function checkForPlatformCmd4InHomebridgeConfigJson()
+{
+   validFile=""
+   for ((tryIndex = 1; tryIndex <= 2; tryIndex ++)); do
+      case $tryIndex in
+         1)
+            validFile=$(grep -n "${cmd4Platform1}" "${configJson}"|cut -d":" -f1)
+            if [ -n "${validFile}" ]; then
+               return
+            fi
+         ;;
+         2)
+            validFile=$(grep -n "${cmd4Platform2}" "${configJson}"|cut -d":" -f1)
+            if [ -n "${validFile}" ]; then
+               return
+            fi
+         ;;
+      esac
+   done
+}
+
+function checkForCmd4PlatformNameInFile()
+{
+   cmd4PlatformNameFound=""
+
+   for ((Index = 1; Index <= 2; Index ++)); do
+      case $Index in
+         1)
+            cmd4PlatformName=$(echo "${cmd4Platform1}"|cut -c13-50)
+            cmd4PlatformNameFound=$(grep -n "${cmd4PlatformName}" "${fullPath}"|cut -d":" -f1)
+            if [ -n "${cmd4PlatformNameFound}" ]; then
+               return
+            fi
+         ;;
+         2)
+            cmd4PlatformName=$(echo "${cmd4Platform2}"|cut -c13-50)
+            cmd4PlatformNameFound=$(grep -n "${cmd4PlatformName}" "${fullPath}"|cut -d":" -f1)
+            if [ -n "${cmd4PlatformNameFound}" ]; then
+               return
+            fi
+         ;;
+      esac
+   done
+}
+
+ 
+function cleanUp()
+{
+   rm -f "${configJson}"
+}
+
+# main starts here
+
+echo "${TYEL}This script is to check that the Cmd4 configuration file meets all requirements${TNRM}"
+echo ""
+
+echo "${TYEL}CheckConfig engine:${TNRM}"
+# get the full path to CheckConfig.js
+CHECKCONFIG_PATH=""
+getGlobalNodeModulesPathForFile "CheckConfig.js"
+if [ -n "${fullPath}" ]; then
+   CHECKCONFIG_PATH=${fullPath}
+   echo "${TLBL}INFO: CheckConfig.js found: ${CHECKCONFIG_PATH}${TNRM}"
+fi
+
+echo ""
+echo "${TYEL}Essential inputs to CheckConfig engine:${TNRM}"
+# get the full path to AdvAir.sh
+ADVAIR_SH_PATH=""
+getGlobalNodeModulesPathForFile "AdvAir.sh"
+if [ -n "${fullPath}" ]; then
+   ADVAIR_SH_PATH=${fullPath}
+   echo "${TLBL}INFO: AdvAir.sh found: ${ADVAIR_SH_PATH}${TNRM}"
+fi
+if [ -z "${ADVAIR_SH_PATH}" ]; then
+   ADVAIR_SH_PATH=""
+   until [ -n "${ADVAIR_SH_PATH}" ]; do
+      echo ""
+      echo "${TYEL}Please enter the full path of where the AdvAir.sh is installed in your system"
+      echo "The file path format should be : /*/*/*/node_modules/homebridge-cmd4-advantageair/AdvAir.sh${TNRM}"
+      read -r -p "${BOLD}> ${TNRM}" INPUT
+      if expr "${INPUT}" : '/[a-zA-Z0-9/_]*/node_modules/homebridge-cmd4-advantageair/AdvAir.sh$' >/dev/null; then
+         if [ -f "${INPUT}" ]; then
+            ADVAIR_SH_PATH=${INPUT}
+            echo ""
+            echo "${TLBL}INFO: AdvAir.sh specified: ${ADVAIR_SH_PATH}${TNRM}"
+            break
+         else
+            echo ""
+            echo "${TPUR}WARNING: file ${INPUT} not found${TNRM}"
+         fi
+      else
+         echo ""
+         echo "${TPUR}WARNING: file ${INPUT} is in wrong format${TNRM}"
+      fi
+   done
+fi
+
+readHomebridgeConfigJson
+
+if [[ -f "${homebridgeConfigJson}" && -f "${ADVAIR_SH_PATH}" ]]; then
+   echo "${TYEL}CheckConfig in progress.......${TNRM}"
+   node "${CHECKCONFIG_PATH}" "$ADVAIR_SH_PATH" "${homebridgeConfigJson}"
+   cleanUp
+fi

--- a/ConfigCreator.sh
+++ b/ConfigCreator.sh
@@ -1293,6 +1293,14 @@ if [ "${rc}" = "0" ]; then
    echo "${TGRN}${BOLD}DONE! Restart Homebridge for the Cmd4 config to take effect${TNRM}" 
    rm -f "${cmd4ConfigJsonAA}"
    cleanUp
+   if [ "${UIversion}" = "nonUI" ]; then
+      getGlobalNodeModulesPathForFile "CheckConfig.sh"
+      check1="${fullPath}"
+      echo ""
+      echo "${TYEL}Please copy/paste and run the following two commands to check whether the Cmd4 configuration meets all the requirements${TNRM}"
+      echo "check1=\"${check1}\""
+      echo "\$check1"
+   fi
 else
    echo "${TRED}${BOLD}ERROR: Copying of \"${cmd4ConfigJsonAA}\" to Homebridge config.json failed!${TNRM}"
    echo "${TLBL}${BOLD}INFO: Instead you can copy/paste the content of \"${cmd4ConfigJsonAA}\" into Cmd4 JASON Config editor.${TNRM}"


### PR DESCRIPTION
---
name: Check Configuration from Command Line
about: Add an improvement to homebridge-cmd4-AdvantageAir.
title: "Check Configuration from Command Line"
labels: Improvement
assignees: mitch7391

---

<!-- Provide a general summary in the Title above -->
Following the success of running `ConfigCreator` from Command-Line for HOOBS users, Mitch has an idea of making `Check Configuration` Command-Line friendly as well for HOOBS users and for those users who have no access to Homebridge-ui.  

I told Mitch that I would explore the `CHECK CONFIGURATION` JavaScript to see whether I can implement that to run from Terminal.   

**Is your pull request related to a problem or a new feature? Please describe:**
<!-- A clear and concise description of what the problem is. E.g. "Mitch, there needs to be a button to buy you a coffee!" -->
An improvement.

**Describe the solution you'd have implemented:**
<!-- A clear and concise description of what you your pull request is for. Explain the technical solution you have provided and how it addresses the issue. -->
### 1. CheckConfig creation:
`CHECK CONFIGURATION` button will invoke `server.js` JavaScript as a child process via html to do the "checking" of `config.json`.  Once I have understood the internal working of the `server.js`, I extracted the main “checking” engine from it and modified some codes around it and in it so that it can be run as a main process from a Terminal using “node.js” rather than a child process called from html.  I called this modified JavaScript `CheckConfig.js`. 
 
The inputs required to this `CheckConfig.js` are the paths to `AdvAir.sh` and `config.json` and the routines looking for those paths have already been coded within `ConfigCreator.sh`.  So I extracted those routines from `ConfigCreator.sh` and created a new bash script called `CheckConfig.sh`.  

So To check the `config.json` using Command-Line, all we need to do is to run the bash script `CheckConfig.sh` which will find the paths and feed those paths into the JavaScript `CheckConfig.js` to do the exact same checking as the `CHECK CONFIGURATION` button in Homebridge-ui.  The messages are exactly the same too but the messages are delivered to the terminal rather than to the Homebridge-ui.

### 2. ConfigCreator minor modification
I have also added a prompt to `ConfigCreator`. The prompt will encourage users to run the `CheckConfig` following a successful `ConfigCreator` run.  The path to run `CheckConfig` is provided as well:

    Please copy/paste and run the following two commands to check whether the Cmd4 configuration meets all the requirements
    check1="/usr/local/lib/node_modules/homebridge-cmd4-advantageair/CheckConfig.sh"
    $check1


**Do your changes pass local testing:**
- [x] Yes
<!-- If unclear, I can update these afterwards. -->

**Additional context:**
<!-- Add any other context or screenshots about the pull request here. -->

### To run the CheckConfig independently, do the following:
1.  Set the Terminal to home drive, so that there is no permission issue:

        cd
 
2.	For Homebridge users:

        check1=$(find /usr/local/lib -name CheckConfig.sh 2>&1|grep -v find|grep -v System|grep -v cache|grep node_modules|grep cmd4-advantageair|grep CheckConfig.sh)

      or

        check1=$(find /usr/lib -name CheckConfig.sh 2>&1|grep -v find|grep -v System|grep -v cache|grep node_modules|grep cmd4-advantageair|grep CheckConfig.sh)
 
      For HOOBS users:

        check1=$(find /var/lib/hoobs -name CheckConfig.sh 2>&1|grep -v find|grep -v System|grep -v cache|grep node_modules|grep cmd4-advantageair|grep CheckConfig.sh)
 
3.   Check the content of **check1**

         echo “$check1”
 
4.   if the response from step 3 is a single file path, then do the following to run the script and ignore the rest of the steps:

         $check1
 
5.  There is little chance that you will find two file paths in step 3, but if you do, do the following to extract the first path or a path of your choice.  To extract the second path, replace **1p** in the following command with **2p**, and so on:
         
         check2=$(echo “${check1}”|sed -n 1p)
6.   Check the content of **check2**

         echo “$check2”

7.   if the response from above is a single file path, then do the following to run the script:

         $check2


### The following is a screen shot of running CheckConfig:
![image](https://user-images.githubusercontent.com/96530237/187815612-6ff91198-11da-462a-86e5-c2fc2feb2e34.png)

if a requirement is not meet, the CheckConfig will throw an error in red color as follow:
![image](https://user-images.githubusercontent.com/96530237/187817920-400c0feb-f392-4b3c-8f8f-25d48aab74bb.png)

Correct the error and run `CheckConfig` again.  Some errors like the example above can be corrected by editing `config.json` directly. If there is an error on **"displayName is defined twice"** especially for lights or garage door, you have to change the name of one of them in your AdvantageAir system and re-run `ConfigCreator` before running `CheckConfig` again.

### A prompt was added to prompt users to run the CheckConfig following a successful run of ConfigCreator:
![image](https://user-images.githubusercontent.com/96530237/187816016-1c75f9c6-01e5-418e-92d4-0a63d032725b.png)

<!-- Click the "Preview" tab before you submit to ensure the formatting is correct. -->
